### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/Season-2/Level-2/code.go
+++ b/Season-2/Level-2/code.go
@@ -70,7 +70,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if password == storedPassword {
-			log.Printf("User %q logged in successfully with a valid password %q", email, password)
+			log.Printf("User %q logged in successfully", email)
 			w.WriteHeader(http.StatusOK)
 		} else {
 			http.Error(w, "Invalid Email or Password", http.StatusUnauthorized)


### PR DESCRIPTION
Potential fix for [https://github.com/DKranzMAT/skills-secure-code-game/security/code-scanning/1](https://github.com/DKranzMAT/skills-secure-code-game/security/code-scanning/1)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged in clear text. Instead, we should log only non-sensitive information or obfuscate the sensitive information before logging it. In this case, we can remove the password from the log message entirely, as logging the email address alone is sufficient for debugging purposes.

We will modify the log statement on line 73 to exclude the password. This change will be made in the `Season-2/Level-2/code.go` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
