### PR TITLE
Potential fix for code scanning alert no. 14: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/Season-1/Level-5/solution.py
+++ b/Season-1/Level-5/solution.py
@@ -1,6 +1,6 @@
 import binascii
 import secrets
-import hashlib
+from argon2 import PasswordHasher
 import os
 import bcrypt
 
@@ -18,25 +18,27 @@ class Random_generator:
     def generate_salt(self, rounds=12):
         return bcrypt.gensalt(rounds)
 
-class SHA256_hasher:
+class Argon2_hasher:
 
-    # produces the password hash by combining password + salt because hashing
-    def password_hash(self, password, salt):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = bcrypt.hashpw(password, salt)
-        return password_hash.decode('ascii')
+    def __init__(self):
+        self.ph = PasswordHasher()
 
-    # verifies that the hashed password reverses to the plain text version on verification
+    # produces the password hash using Argon2
+    def password_hash(self, password):
+        return self.ph.hash(password)
+
+    # verifies that the hashed password matches the plain text version
     def password_verification(self, password, password_hash):
-        password = binascii.hexlify(hashlib.sha256(password.encode()).digest())
-        password_hash = password_hash.encode('ascii')
-        return bcrypt.checkpw(password, password_hash)
+        try:
+            return self.ph.verify(password_hash, password)
+        except:
+            return False
 
 # a collection of sensitive secrets necessary for the software to operate
 PRIVATE_KEY = os.environ.get('PRIVATE_KEY')
 PUBLIC_KEY = os.environ.get('PUBLIC_KEY')
 SECRET_KEY = os.environ.get('SECRET_KEY')
-PASSWORD_HASHER = 'SHA256_hasher'
+PASSWORD_HASHER = 'Argon2_hasher'
 
 # Solution explanation:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask-testing
 blinker
 requests
+argon2-cffi==23.1.0


### PR DESCRIPTION
Potential fix for [https://github.com/DKranzMAT/skills-secure-code-game/security/code-scanning/14](https://github.com/DKranzMAT/skills-secure-code-game/security/code-scanning/14)

To fix the problem, we should replace the use of SHA-256 with a more suitable password hashing algorithm such as Argon2, which is designed to be computationally expensive and includes a per-password salt by default. This will ensure that the password hashing is secure and resistant to brute-force attacks.

We will need to:
1. Import the `argon2` library.
2. Replace the `password_hash` and `password_verification` methods to use Argon2 instead of SHA-256 and bcrypt.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
